### PR TITLE
chore: bump to v0.13.1

### DIFF
--- a/Formula/vela.rb
+++ b/Formula/vela.rb
@@ -8,16 +8,16 @@ class Vela < Formula
   homepage 'https://github.com/go-vela/cli'
 
   # utility information
-  version 'v0.13.0'
+  version 'v0.13.1'
 
   # macOS
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 '1699ab8304dcb49cba6522e48ee472a7d5952dd4ae68b0e800c760980eca3ef6'
+      sha256 '1bca393b3c7d3ceb5f86ff30f619d247717d7f0c6a1ce30daa50b2d0e96e50b9'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
-      sha256 'ecdde72501b52edecbaa5b4ce5f7e9652e76fd42d344d900c76da32325517d34'
+      sha256 'ee34edd6c121c1792b08a148fe1dccb12491182a92d165720e30e643fc0d3d70'
     end
   end
 
@@ -26,14 +26,14 @@ class Vela < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 '91eeac33663dc62252c5a275dc0aa96f020833fc031d5b3fdd34f56f9d08ad37'
+        sha256 'a61d34bd4f5825da3393847a2c6cd8c993780e3d4f2e0553963fbdf3752eeb66'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 'e8417d3e2cd154c445d618ca4fba17e73d3bdf8f41d3d6e639c8228b0ebd7a6a'
+        sha256 '7a0460bd878de57246e6dbfde8adf03f4da1db6ada69c5c23c58abf31bd04d07'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 '7a2dc79963b64c5d8853f1d4c3c1136c5f9b35686131dee901478f1899fcffea'
+      sha256 '60ebbfaf507d4218b49c0d6343910e21de407640243672c11664381537862f8a'
     end
   end
 

--- a/Formula/vela@0.12.rb
+++ b/Formula/vela@0.12.rb
@@ -10,16 +10,16 @@ class VelaAT012 < Formula
   homepage 'https://github.com/go-vela/cli'
 
   # utility information
-  version 'v0.12.0'
+  version 'v0.12.1'
 
   # macOS
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 'ded77d0c12730a3f8e7d3df59c5575e57d79f2c05991090d7c66281a844162b6'
+      sha256 'd2858b16c9532fd96d1d81fdca2f41780a08d44a016a06dc185499b3a1b4e8e5'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
-      sha256 '8bb18ccc9b04a96e3d627e391cea981ebb8ed328c40c6735a280c1fdab9edbfe'
+      sha256 '3cb6f96cecfd039244c00acba6d6e0d755b17d680c34c4265eb26f1c4764eb00'
     end
   end
 
@@ -28,14 +28,14 @@ class VelaAT012 < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 'fd20b14908d58772d93e79877c4339a2f99dd901a4b12269b91d49be7bf93963'
+        sha256 'da8f0eb9f4fd4d76d7e433c0aec07ad02a51c6ffc42addaff89ba82d34a20522'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 '076ef6616e7debef7867bfc8a4490884c63015f932354ecadeec1452498777d1'
+        sha256 '4f50ec9cdf83b00097ba175ea03c15e15236c5ca569d75ac43e3affd93a880d6'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 '9455421cd8cfc6742c28800ee4946844109bcc3c5feb246b38a2aa74b63c6105'
+      sha256 '5dc3673ad11b5fdff50b51d1ae493d4b1deb3a313b645603eefa3721f84bedf7'
     end
   end
 

--- a/Formula/vela@0.13.rb
+++ b/Formula/vela@0.13.rb
@@ -10,16 +10,16 @@ class VelaAT013 < Formula
   homepage 'https://github.com/go-vela/cli'
 
   # utility information
-  version 'v0.13.0'
+  version 'v0.13.1'
 
   # macOS
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 '1699ab8304dcb49cba6522e48ee472a7d5952dd4ae68b0e800c760980eca3ef6'
+      sha256 '1bca393b3c7d3ceb5f86ff30f619d247717d7f0c6a1ce30daa50b2d0e96e50b9'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
-      sha256 'ecdde72501b52edecbaa5b4ce5f7e9652e76fd42d344d900c76da32325517d34'
+      sha256 'ee34edd6c121c1792b08a148fe1dccb12491182a92d165720e30e643fc0d3d70'
     end
   end
 
@@ -28,14 +28,14 @@ class VelaAT013 < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 '91eeac33663dc62252c5a275dc0aa96f020833fc031d5b3fdd34f56f9d08ad37'
+        sha256 'a61d34bd4f5825da3393847a2c6cd8c993780e3d4f2e0553963fbdf3752eeb66'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 'e8417d3e2cd154c445d618ca4fba17e73d3bdf8f41d3d6e639c8228b0ebd7a6a'
+        sha256 '7a0460bd878de57246e6dbfde8adf03f4da1db6ada69c5c23c58abf31bd04d07'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 '7a2dc79963b64c5d8853f1d4c3c1136c5f9b35686131dee901478f1899fcffea'
+      sha256 '60ebbfaf507d4218b49c0d6343910e21de407640243672c11664381537862f8a'
     end
   end
 


### PR DESCRIPTION
updating to use latest released version

for reference:
v0.13.1 checksums - https://github.com/go-vela/cli/releases/download/v0.13.1/vela_checksums.txt
v0.12.1 checksums - https://github.com/go-vela/cli/releases/download/v0.12.1/vela_checksums.txt