### PR TITLE
chore(release): upgrade checksums to v0.21.0 + scripting

### DIFF
--- a/Formula/vela.rb
+++ b/Formula/vela.rb
@@ -14,7 +14,7 @@ class Vela < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 '229a32ede0736f8db775aaf768e8151f601c67824d9c8a663109e251a47f534d'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
       sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
@@ -26,14 +26,14 @@ class Vela < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 '07be9f007379001879ad0c1fb8509a5f2b2ec99a20529c10ea0b02a43dd7d6ba'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 '1f0c3613ade1e4a8b56a8cdc2beadf83f76efb59300fe5c83ce49308ded84988'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 '9d3624aa478c5ecf610a14ec17894a7760ec5e015cbca3ae31c075a9f0e627d8'
     end
   end
 

--- a/Formula/vela@0.21.rb
+++ b/Formula/vela@0.21.rb
@@ -16,7 +16,7 @@ class VelaAT021 < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 '229a32ede0736f8db775aaf768e8151f601c67824d9c8a663109e251a47f534d'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
       sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
@@ -28,14 +28,14 @@ class VelaAT021 < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 '07be9f007379001879ad0c1fb8509a5f2b2ec99a20529c10ea0b02a43dd7d6ba'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 '1f0c3613ade1e4a8b56a8cdc2beadf83f76efb59300fe5c83ce49308ded84988'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 '9d3624aa478c5ecf610a14ec17894a7760ec5e015cbca3ae31c075a9f0e627d8'
     end
   end
 

--- a/Formula/vela@0.21.rb
+++ b/Formula/vela@0.21.rb
@@ -2,7 +2,9 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
-class Vela < Formula
+require 'formula'
+
+class VelaAT021 < Formula
   # repository information
   head 'https://github.com/go-vela/cli.git'
   homepage 'https://github.com/go-vela/cli'

--- a/sha_update.sh
+++ b/sha_update.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+function sha_update() {
+  local VELA_VERSION=$1
+  local CHECKSUMS_PATH=$2
+
+  local HEADER="# Copyright (c) 2023 Target Brands, Inc. All rights reserved.\n#\n# Use of this source code is governed by the LICENSE file in this repository.\n"
+
+  local LINUX_AMD64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local LINUX_ARM64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local LINUX_ARM=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local DARWIN_AMD64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local DARWIN_ARM64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+
+  echo -e $HEADER > Formula/vela.rb
+
+  sed "s/VELA_VERSION/$VELA_VERSION/g" template.rb >> tmp.rb
+
+  sed -i -e "s/DARWIN_ARM64_SHA/$DARWIN_ARM64/g" tmp.rb
+  sed -i -e "s/DARWIN_AMD64_SHA/$DARWIN_AMD64/g" tmp.rb
+  sed -i -e "s/LINUX_ARM64_SHA/$LINUX_ARM64/g" tmp.rb
+  sed -i -e "s/LINUX_ARM_SHA/$LINUX_ARM/g" tmp.rb
+  sed -i -e "s/LINUX_AMD64_SHA/$LINUX_AMD64/g" tmp.rb
+
+  rm tmp.rb-e
+
+  cat tmp.rb >> Formula/vela.rb
+
+  local DIRECT_PATH=$(echo $VELA_VERSION | sed "s/v//g" | awk -F '\.' '{print $1"."$2}' )
+
+  local TARGET_VER=$(echo $VELA_VERSION | sed "s/v//g" | awk -F '\.' '{print $1$2}')
+
+  echo -e $HEADER > Formula/vela@$DIRECT_PATH.rb
+
+  echo -e "require 'formula'" >> Formula/vela@$DIRECT_PATH.rb
+
+  echo -e "\nclass VelaAT$TARGET_VER < Formula" >> Formula/vela@$DIRECT_PATH.rb
+
+  sed '1d' tmp.rb >> Formula/vela@$DIRECT_PATH.rb
+
+  rm tmp.rb
+}
+
+function main() {
+  local VELA_VERSION=$1
+  local CHECKSUMS_PATH=$2
+
+  sha_update "$VELA_VERSION" "$CHECKSUMS_PATH"
+}
+
+main "$@"

--- a/sha_update.sh
+++ b/sha_update.sh
@@ -6,11 +6,11 @@ function sha_update() {
 
   local HEADER="# Copyright (c) 2023 Target Brands, Inc. All rights reserved.\n#\n# Use of this source code is governed by the LICENSE file in this repository.\n"
 
-  local LINUX_AMD64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
-  local LINUX_ARM64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
-  local LINUX_ARM=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local LINUX_AMD64=$(cat $CHECKSUMS_PATH | grep linux_amd64 | awk '{ print $1 }')
+  local LINUX_ARM64=$(cat $CHECKSUMS_PATH | grep linux_arm64 | awk '{ print $1 }')
+  local LINUX_ARM=$(cat $CHECKSUMS_PATH | grep linux_arm.tar | awk '{ print $1 }')
   local DARWIN_AMD64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
-  local DARWIN_ARM64=$(cat $CHECKSUMS_PATH | grep darwin_amd64 | awk '{ print $1 }')
+  local DARWIN_ARM64=$(cat $CHECKSUMS_PATH | grep darwin_arm64 | awk '{ print $1 }')
 
   echo -e $HEADER > Formula/vela.rb
 

--- a/template.rb
+++ b/template.rb
@@ -1,23 +1,19 @@
-# Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-#
-# Use of this source code is governed by the LICENSE file in this repository.
-
 class Vela < Formula
   # repository information
   head 'https://github.com/go-vela/cli.git'
   homepage 'https://github.com/go-vela/cli'
 
   # utility information
-  version 'v0.21.0'
+  version 'VELA_VERSION'
 
   # macOS
   on_macos do
     if Hardware::CPU.arm?
       url "#{homepage}/releases/download/#{version}/vela_darwin_arm64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 'DARWIN_ARM64_SHA'
     else
       url "#{homepage}/releases/download/#{version}/vela_darwin_amd64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 'DARWIN_AMD64_SHA'
     end
   end
 
@@ -26,14 +22,14 @@ class Vela < Formula
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "#{homepage}/releases/download/#{version}/vela_linux_arm64.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 'LINUX_ARM64_SHA'
       else
         url "#{homepage}/releases/download/#{version}/vela_linux_arm.tar.gz"
-        sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+        sha256 'LINUX_ARM_SHA'
       end
     else
       url "#{homepage}/releases/download/#{version}/vela_linux_amd64.tar.gz"
-      sha256 'f299d513615df5913f55f6c288b9a8e167df98d46522dcd9646b9380731d5885'
+      sha256 'LINUX_AMD64_SHA'
     end
   end
 


### PR DESCRIPTION
Updating checksums for `v0.21.0`.

Also added a script to make this easier in the future

```sh
$ ./sha_update.sh <VERSION> <PATH_TO_CHECKSUMS.TXT>
```

The above will generate a new `Formula/vela@<version>.rb` file and update the `Formula/vela.rb` file to use the checksums specified in the file.